### PR TITLE
Add basic capture service

### DIFF
--- a/SleekySnip.sln
+++ b/SleekySnip.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36202.13
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreferencePane", "src\interfaces\prefpane.ui\PrefrencePane\PreferencePane.csproj", "{EF550CA2-2C67-407E-981E-A0C23593AEBC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreferencePane", "src\interfaces\PreferencePane\PreferencePane.csproj", "{EF550CA2-2C67-407E-981E-A0C23593AEBC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "llsvc.capture", "src\services\llsvc.capture\llsvc.capture.csproj", "{2A3D2987-FE84-487D-BEE2-970B7CE3BB35}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,24 @@ Global
 		{EF550CA2-2C67-407E-981E-A0C23593AEBC}.Release|x86.ActiveCfg = Release|x86
 		{EF550CA2-2C67-407E-981E-A0C23593AEBC}.Release|x86.Build.0 = Release|x86
 		{EF550CA2-2C67-407E-981E-A0C23593AEBC}.Release|x86.Deploy.0 = Release|x86
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|ARM64.ActiveCfg = Debug|ARM64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|ARM64.Build.0 = Debug|ARM64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|ARM64.Deploy.0 = Debug|ARM64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|x64.ActiveCfg = Debug|x64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|x64.Build.0 = Debug|x64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|x64.Deploy.0 = Debug|x64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|x86.ActiveCfg = Debug|x86
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|x86.Build.0 = Debug|x86
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Debug|x86.Deploy.0 = Debug|x86
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|ARM64.ActiveCfg = Release|ARM64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|ARM64.Build.0 = Release|ARM64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|ARM64.Deploy.0 = Release|ARM64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|x64.ActiveCfg = Release|x64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|x64.Build.0 = Release|x64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|x64.Deploy.0 = Release|x64
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|x86.ActiveCfg = Release|x86
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|x86.Build.0 = Release|x86
+                {2A3D2987-FE84-487D-BEE2-970B7CE3BB35}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/interfaces/PreferencePane/PreferencePane.csproj
+++ b/src/interfaces/PreferencePane/PreferencePane.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>PreferencePane</RootNamespace>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,1 +1,9 @@
-'llsvc'=low level services
+# llsvc - low level services
+
+This folder contains background components for SleekySnip.
+
+## Capture Service (`llsvc.capture`)
+
+The capture service registers `Ctrl+Shift+S` as a global hotkey. When pressed,
+it opens a small WPF window with options to capture an area, window or the full
+screen. The current window is a placeholder for future capture logic.

--- a/src/services/llsvc.capture/App.xaml
+++ b/src/services/llsvc.capture/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="LLSvc.Capture.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="CaptureWindow.xaml">
+</Application>

--- a/src/services/llsvc.capture/App.xaml.cs
+++ b/src/services/llsvc.capture/App.xaml.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace LLSvc.Capture
+{
+    public partial class App : Application
+    {
+        private HwndSource? _source;
+        private Window? _messageWindow;
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            _messageWindow = new Window
+            {
+                Width = 0,
+                Height = 0,
+                WindowStyle = WindowStyle.None,
+                ShowInTaskbar = false,
+                AllowsTransparency = true,
+                Opacity = 0
+            };
+            _messageWindow.SourceInitialized += (_, __) =>
+            {
+                var helper = new WindowInteropHelper(_messageWindow);
+                _source = HwndSource.FromHwnd(helper.Handle);
+                _source.AddHook(HwndHook);
+                HotKeyManager.Register(helper.Handle);
+            };
+            _messageWindow.Show();
+            _messageWindow.Hide();
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            if (_source != null)
+            {
+                _source.RemoveHook(HwndHook);
+                var helper = new WindowInteropHelper(_messageWindow);
+                HotKeyManager.Unregister(helper.Handle);
+            }
+            base.OnExit(e);
+        }
+
+        private IntPtr HwndHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            const int WM_HOTKEY = 0x0312;
+            if (msg == WM_HOTKEY && wParam.ToInt32() == HotKeyManager.HOTKEY_ID)
+            {
+                var captureWindow = new CaptureWindow();
+                captureWindow.Show();
+                handled = true;
+            }
+            return IntPtr.Zero;
+        }
+    }
+
+    internal static class HotKeyManager
+    {
+        public const int HOTKEY_ID = 9000;
+        private const uint MOD_CONTROL = 0x0002;
+        private const uint MOD_SHIFT = 0x0004;
+        private const uint VK_S = 0x53; // S key
+
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        public static bool Register(IntPtr handle)
+        {
+            return RegisterHotKey(handle, HOTKEY_ID, MOD_CONTROL | MOD_SHIFT, VK_S);
+        }
+
+        public static void Unregister(IntPtr handle)
+        {
+            UnregisterHotKey(handle, HOTKEY_ID);
+        }
+    }
+}

--- a/src/services/llsvc.capture/CaptureWindow.xaml
+++ b/src/services/llsvc.capture/CaptureWindow.xaml
@@ -1,0 +1,11 @@
+<Window x:Class="LLSvc.Capture.CaptureWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Capture" Height="200" Width="300">
+    <StackPanel Margin="20">
+        <TextBlock Text="Select capture mode:" Margin="0,0,0,10" />
+        <Button Content="Area" Margin="0,0,0,5" />
+        <Button Content="Window" Margin="0,0,0,5" />
+        <Button Content="Screen" />
+    </StackPanel>
+</Window>

--- a/src/services/llsvc.capture/CaptureWindow.xaml.cs
+++ b/src/services/llsvc.capture/CaptureWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace LLSvc.Capture
+{
+    public partial class CaptureWindow : Window
+    {
+        public CaptureWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/services/llsvc.capture/llsvc.capture.csproj
+++ b/src/services/llsvc.capture/llsvc.capture.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add `llsvc.capture` WPF module registering Ctrl+Shift+S global hotkey
- basic capture window with buttons for area, window and screen
- document capture service
- update solution file to include new project
- enable Windows targeting for Windows-based projects

## Testing
- `dotnet build SleekySnip.sln` *(fails: Microsoft.UI.Xaml references missing)*

------
https://chatgpt.com/codex/tasks/task_e_68463a3efa04832e86d71821124d94be