### PR TITLE
Add WinSnip.Core library and props utilities

### DIFF
--- a/SleekySnip.sln
+++ b/SleekySnip.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36202.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreferencePane", "src\interfaces\prefpane.ui\PrefrencePane\PreferencePane.csproj", "{EF550CA2-2C67-407E-981E-A0C23593AEBC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SleekySnip.Core", "src\SleekySnip.Core\SleekySnip.Core.csproj", "{74A931F5-F4B8-4084-BF93-39AF9B73E11F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -33,6 +35,24 @@ Global
 		{EF550CA2-2C67-407E-981E-A0C23593AEBC}.Release|x86.ActiveCfg = Release|x86
 		{EF550CA2-2C67-407E-981E-A0C23593AEBC}.Release|x86.Build.0 = Release|x86
 		{EF550CA2-2C67-407E-981E-A0C23593AEBC}.Release|x86.Deploy.0 = Release|x86
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|ARM64.ActiveCfg = Debug|ARM64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|ARM64.Build.0 = Debug|ARM64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|ARM64.Deploy.0 = Debug|ARM64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|x64.ActiveCfg = Debug|x64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|x64.Build.0 = Debug|x64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|x64.Deploy.0 = Debug|x64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|x86.ActiveCfg = Debug|x86
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|x86.Build.0 = Debug|x86
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Debug|x86.Deploy.0 = Debug|x86
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|ARM64.ActiveCfg = Release|ARM64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|ARM64.Build.0 = Release|ARM64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|ARM64.Deploy.0 = Release|ARM64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x64.ActiveCfg = Release|x64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x64.Build.0 = Release|x64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x64.Deploy.0 = Release|x64
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x86.ActiveCfg = Release|x86
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x86.Build.0 = Release|x86
+                {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/resources/SleekySnip.props
+++ b/resources/SleekySnip.props
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SleekySnipSettings>
+  <Hotkey>PrintScreen</Hotkey>
+  <CaptureMode>Region</CaptureMode>
+</SleekySnipSettings>

--- a/src/SleekySnip.Core/SleekySnip.Core.csproj
+++ b/src/SleekySnip.Core/SleekySnip.Core.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/SleekySnip.Core/SleekySnipSettings.cs
+++ b/src/SleekySnip.Core/SleekySnipSettings.cs
@@ -1,0 +1,7 @@
+namespace SleekySnip.Core;
+
+public class SleekySnipSettings
+{
+    public string Hotkey { get; set; } = "PrintScreen";
+    public string CaptureMode { get; set; } = "Region";
+}

--- a/src/SleekySnip.Core/SleekySnipSettingsSerializer.cs
+++ b/src/SleekySnip.Core/SleekySnipSettingsSerializer.cs
@@ -1,0 +1,49 @@
+using System.Xml;
+using System.IO;
+
+namespace SleekySnip.Core;
+
+public static class SleekySnipSettingsSerializer
+{
+    public static SleekySnipSettings Load(string path)
+    {
+        var settings = new SleekySnipSettings();
+        if (!File.Exists(path))
+            return settings;
+
+        var doc = new XmlDocument();
+        doc.Load(path);
+        var root = doc.DocumentElement;
+        if (root == null)
+            return settings;
+
+        if (root["Hotkey"] != null)
+            settings.Hotkey = root["Hotkey"]!.InnerText;
+        if (root["CaptureMode"] != null)
+            settings.CaptureMode = root["CaptureMode"]!.InnerText;
+        return settings;
+    }
+
+    public static void Save(SleekySnipSettings settings, string path)
+    {
+        var doc = new XmlDocument();
+        var declaration = doc.CreateXmlDeclaration("1.0", "utf-8", null);
+        doc.AppendChild(declaration);
+
+        var root = doc.CreateElement("SleekySnipSettings");
+        doc.AppendChild(root);
+
+        var hotkey = doc.CreateElement("Hotkey");
+        hotkey.InnerText = settings.Hotkey;
+        root.AppendChild(hotkey);
+
+        var capture = doc.CreateElement("CaptureMode");
+        capture.InnerText = settings.CaptureMode;
+        root.AppendChild(capture);
+
+        var xmlWriterSettings = new XmlWriterSettings { Indent = true };
+        using var writer = XmlWriter.Create(path, xmlWriterSettings);
+        doc.Save(writer);
+    }
+}
+

--- a/src/interfaces/PreferencePane/PreferencePane.csproj
+++ b/src/interfaces/PreferencePane/PreferencePane.csproj
@@ -52,4 +52,7 @@
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\SleekySnip.Core\SleekySnip.Core.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add `WinSnip.props` with default hotkey and capture mode
- implement `WinSnip.Core` library for reading/writing the `.props` file
- reference the new library from `PreferencePane`
- register `WinSnip.Core` in the solution

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463a5c6798832e9c6d0ac3372565b7