### PR TITLE
Add dotnet build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # SleekySnip
+
+## Building
+
+Run `dotnet build` from the project root to ensure the solution compiles:
+
+```bash
+dotnet build SleekySnip.sln
+```
+
+Successful builds end with `Build succeeded.`. If `dotnet` is not found, install the .NET SDK 8.0 or later.


### PR DESCRIPTION
## Summary
- update documentation on how to compile the solution with `dotnet build`

## Testing
- `dotnet build SleekySnip.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684644144ba0832e94cb2e076e3ba01a