### PR TITLE
Add output folder preference with screenshot saving

### DIFF
--- a/resources/SleekySnip.props
+++ b/resources/SleekySnip.props
@@ -2,4 +2,5 @@
 <SleekySnipSettings>
   <Hotkey>PrintScreen</Hotkey>
   <CaptureMode>Region</CaptureMode>
+  <OutputFolder></OutputFolder>
 </SleekySnipSettings>

--- a/src/SleekySnip.Core/CaptureManager.cs
+++ b/src/SleekySnip.Core/CaptureManager.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Windows.Forms;
+
+namespace SleekySnip.Core;
+
+public static class CaptureManager
+{
+    public static void CaptureScreen(SleekySnipSettings settings)
+    {
+        using var bitmap = new Bitmap(Screen.PrimaryScreen.Bounds.Width, Screen.PrimaryScreen.Bounds.Height);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.CopyFromScreen(0, 0, 0, 0, bitmap.Size);
+
+        // copy to clipboard
+        Clipboard.SetImage(bitmap);
+
+        // save to file if output folder configured
+        if (!string.IsNullOrWhiteSpace(settings.OutputFolder))
+        {
+            Directory.CreateDirectory(settings.OutputFolder);
+            var file = Path.Combine(settings.OutputFolder, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            bitmap.Save(file, ImageFormat.Png);
+        }
+    }
+}

--- a/src/SleekySnip.Core/SleekySnip.Core.csproj
+++ b/src/SleekySnip.Core/SleekySnip.Core.csproj
@@ -2,5 +2,9 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/SleekySnip.Core/SleekySnipSettings.cs
+++ b/src/SleekySnip.Core/SleekySnipSettings.cs
@@ -4,4 +4,5 @@ public class SleekySnipSettings
 {
     public string Hotkey { get; set; } = "PrintScreen";
     public string CaptureMode { get; set; } = "Region";
+    public string OutputFolder { get; set; } = string.Empty;
 }

--- a/src/SleekySnip.Core/SleekySnipSettingsSerializer.cs
+++ b/src/SleekySnip.Core/SleekySnipSettingsSerializer.cs
@@ -21,6 +21,8 @@ public static class SleekySnipSettingsSerializer
             settings.Hotkey = root["Hotkey"]!.InnerText;
         if (root["CaptureMode"] != null)
             settings.CaptureMode = root["CaptureMode"]!.InnerText;
+        if (root["OutputFolder"] != null)
+            settings.OutputFolder = root["OutputFolder"]!.InnerText;
         return settings;
     }
 
@@ -40,6 +42,10 @@ public static class SleekySnipSettingsSerializer
         var capture = doc.CreateElement("CaptureMode");
         capture.InnerText = settings.CaptureMode;
         root.AppendChild(capture);
+
+        var folder = doc.CreateElement("OutputFolder");
+        folder.InnerText = settings.OutputFolder;
+        root.AppendChild(folder);
 
         var xmlWriterSettings = new XmlWriterSettings { Indent = true };
         using var writer = XmlWriter.Create(path, xmlWriterSettings);

--- a/src/interfaces/PreferencePane/MainWindow.xaml
+++ b/src/interfaces/PreferencePane/MainWindow.xaml
@@ -14,6 +14,12 @@
     </Window.SystemBackdrop>
 
     <Grid>
-
+        <StackPanel Margin="20" Spacing="10">
+            <TextBlock Text="Output Folder" />
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <TextBox x:Name="OutputFolderTextBox" Width="300" />
+                <Button Content="Browse..." Click="BrowseOutputFolder_Click" />
+            </StackPanel>
+        </StackPanel>
     </Grid>
 </Window>

--- a/src/interfaces/PreferencePane/MainWindow.xaml.cs
+++ b/src/interfaces/PreferencePane/MainWindow.xaml.cs
@@ -12,6 +12,8 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -23,9 +25,29 @@ namespace PreferencePane
     /// </summary>
     public sealed partial class MainWindow : Window
     {
+        private readonly string _settingsPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "resources", "SleekySnip.props");
+        private SleekySnip.Core.SleekySnipSettings _settings;
+
         public MainWindow()
         {
             InitializeComponent();
+            _settings = SleekySnip.Core.SleekySnipSettingsSerializer.Load(_settingsPath);
+            OutputFolderTextBox.Text = _settings.OutputFolder;
+        }
+
+        private async void BrowseOutputFolder_Click(object sender, RoutedEventArgs e)
+        {
+            var picker = new Windows.Storage.Pickers.FolderPicker();
+            picker.FileTypeFilter.Add("*");
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+            var folder = await picker.PickSingleFolderAsync();
+            if (folder != null)
+            {
+                _settings.OutputFolder = folder.Path;
+                OutputFolderTextBox.Text = _settings.OutputFolder;
+                SleekySnip.Core.SleekySnipSettingsSerializer.Save(_settings, _settingsPath);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `OutputFolder` setting to `SleekySnipSettings`
- persist `OutputFolder` in serializer and default props
- implement `CaptureManager` that saves screenshots to a configured folder and copies them to the clipboard
- update preference pane UI to select output folder and save to settings file
- enable Windows Forms for screenshot capture

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684644075c60832eb23558653f5a1e85