### PR TITLE
Fix Windows target properties

### DIFF
--- a/src/SleekySnip.Core/SleekySnip.Core.csproj
+++ b/src/SleekySnip.Core/SleekySnip.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- specify Windows target framework in SleekySnip.Core to avoid TargetPlatformVersion errors

## Testing
- `dotnet build SleekySnip.sln -c Release -p:EnableWindowsTargeting=true` *(fails: Unable to find package WinRT.Runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68464913fa50832ebc93a7c9e2226aff