### PR TITLE
Add global hotkey listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 SleekySnip is a simple example project that targets Windows 10 and later using .NET 8 and WinUI.
 
+The repository also includes a low level keyboard listener service (`llsvc.keyboardlistener`) used for capturing global hotkeys. The preference pane starts this listener at launch so pressing the configured hotkey shows the capture flyout.
+
 ## Prerequisites
 
 - **Windows 10 or later** – this project requires the Windows 10 SDK and features available on Windows 10 and newer.

--- a/SleekySnip.sln
+++ b/SleekySnip.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreferencePane", "src\inter
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SleekySnip.Core", "src\SleekySnip.Core\SleekySnip.Core.csproj", "{74A931F5-F4B8-4084-BF93-39AF9B73E11F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "llsvc.keyboardlistener", "src\services\llsvc.keyboardlistener\llsvc.keyboardlistener.csproj", "{91A04BAD-68ED-4140-9922-3AECD58B5DEE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -53,8 +55,26 @@ Global
                 {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x86.ActiveCfg = Release|x86
                 {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x86.Build.0 = Release|x86
                 {74A931F5-F4B8-4084-BF93-39AF9B73E11F}.Release|x86.Deploy.0 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|ARM64.ActiveCfg = Debug|ARM64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|ARM64.Build.0 = Debug|ARM64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|ARM64.Deploy.0 = Debug|ARM64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|x64.ActiveCfg = Debug|x64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|x64.Build.0 = Debug|x64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|x64.Deploy.0 = Debug|x64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|x86.ActiveCfg = Debug|x86
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|x86.Build.0 = Debug|x86
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Debug|x86.Deploy.0 = Debug|x86
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|ARM64.ActiveCfg = Release|ARM64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|ARM64.Build.0 = Release|ARM64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|ARM64.Deploy.0 = Release|ARM64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|x64.ActiveCfg = Release|x64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|x64.Build.0 = Release|x64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|x64.Deploy.0 = Release|x64
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|x86.ActiveCfg = Release|x86
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|x86.Build.0 = Release|x86
+                {91A04BAD-68ED-4140-9922-3AECD58B5DEE}.Release|x86.Deploy.0 = Release|x86
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/src/interfaces/PreferencePane/CaptureManager.cs
+++ b/src/interfaces/PreferencePane/CaptureManager.cs
@@ -1,36 +1,15 @@
 using Microsoft.UI.Xaml;
-using System.Windows.Forms;
 using Windows.System;
 using SleekySnip.Core;
 using System.IO;
+using Llsvc.KeyboardListener;
 
 namespace PreferencePane;
 
 public static class CaptureManager
 {
     private static CaptureWindow? _window;
-    private static HotKeyRegistrar? _registrar;
-    private static MessageWindow? _messageWindow;
-
-    private const int WM_HOTKEY = 0x0312;
-
-    private sealed class MessageWindow : NativeWindow
-    {
-        public MessageWindow()
-        {
-            CreateHandle(new CreateParams());
-        }
-
-        protected override void WndProc(ref Message m)
-        {
-            if (m.Msg == WM_HOTKEY)
-            {
-                ShowFlyout();
-            }
-
-            base.WndProc(ref m);
-        }
-    }
+    private static KeyboardListener? _listener;
 
     public static void ShowFlyout()
     {
@@ -45,10 +24,8 @@ public static class CaptureManager
 
     public static void Initialize()
     {
-        if (_messageWindow != null)
+        if (_listener != null)
             return;
-
-        _messageWindow = new MessageWindow();
 
         var settingsPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "resources", "SleekySnip.props");
         var settings = SleekySnip.Core.SleekySnipSettingsSerializer.Load(settingsPath);
@@ -56,17 +33,17 @@ public static class CaptureManager
         VirtualKey key = VirtualKey.Snapshot;
         Enum.TryParse(settings.Hotkey, out key);
 
-        _registrar = new SleekySnip.Core.HotKeyRegistrar(_messageWindow.Handle);
-        _registrar.TryRegister(0, (uint)key);
+        _listener = new KeyboardListener();
+        _listener.SetProcessCommand(id => ShowFlyout());
+        _listener.SetHotkeyAction(win: false, ctrl: false, shift: false, alt: false, key: (byte)key, id: "capture");
+        _listener.Start();
 
         Application.Current.Exit += OnAppExit;
     }
 
     private static void OnAppExit(object sender, object e)
     {
-        _registrar?.Dispose();
-        _registrar = null;
-        _messageWindow?.DestroyHandle();
-        _messageWindow = null;
+        _listener?.Dispose();
+        _listener = null;
     }
 }

--- a/src/interfaces/PreferencePane/PreferencePane.csproj
+++ b/src/interfaces/PreferencePane/PreferencePane.csproj
@@ -11,7 +11,6 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
-    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/services/llsvc.keyboardlistener/KeyboardListener.cs
+++ b/src/services/llsvc.keyboardlistener/KeyboardListener.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Llsvc.KeyboardListener;
+
+public class KeyboardListener : IDisposable
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KBDLLHOOKSTRUCT
+    {
+        public uint vkCode;
+        public uint scanCode;
+        public uint flags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    private delegate IntPtr LowLevelProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+    private const int WH_KEYBOARD_LL = 13;
+    private const int WM_KEYDOWN = 0x0100;
+    private const int WM_SYSKEYDOWN = 0x0104;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelProc lpfn, IntPtr hMod, uint dwThreadId);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern short GetAsyncKeyState(int vKey);
+
+    [DllImport("user32.dll")]
+    private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT
+    {
+        public uint type;
+        public InputUnion u;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct InputUnion
+    {
+        [FieldOffset(0)]
+        public KEYBDINPUT ki;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    private const int INPUT_KEYBOARD = 1;
+    private const uint KEYEVENTF_KEYUP = 0x0002;
+
+    public record struct Hotkey(bool Win, bool Ctrl, bool Shift, bool Alt, byte Key);
+
+    public delegate void ProcessCommand(string id);
+
+    private readonly SortedDictionary<Hotkey, string> _hotkeyMap = new(new HotkeyComparer());
+    private readonly LowLevelProc _proc;
+    private IntPtr _hook;
+    private ProcessCommand? _processCommand;
+
+    public KeyboardListener()
+    {
+        _proc = HookCallback;
+    }
+
+    public void Start()
+    {
+        if (_hook == IntPtr.Zero)
+        {
+            _hook = SetWindowsHookEx(WH_KEYBOARD_LL, _proc, IntPtr.Zero, 0);
+            if (_hook == IntPtr.Zero)
+            {
+                throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+    }
+
+    public void Stop()
+    {
+        if (_hook != IntPtr.Zero)
+        {
+            UnhookWindowsHookEx(_hook);
+            _hook = IntPtr.Zero;
+        }
+    }
+
+    public void SetHotkeyAction(bool win, bool ctrl, bool shift, bool alt, byte key, string id)
+    {
+        var hotkey = new Hotkey(win, ctrl, shift, alt, key);
+        _hotkeyMap[hotkey] = id;
+    }
+
+    public void ClearHotkey(string id)
+    {
+        foreach (var kv in new List<KeyValuePair<Hotkey, string>>(_hotkeyMap))
+        {
+            if (kv.Value == id)
+            {
+                _hotkeyMap.Remove(kv.Key);
+            }
+        }
+    }
+
+    public void ClearHotkeys() => _hotkeyMap.Clear();
+
+    public void SetProcessCommand(ProcessCommand processCommand)
+    {
+        _processCommand = processCommand;
+    }
+
+    private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        if (nCode >= 0 && (wParam == (IntPtr)WM_KEYDOWN || wParam == (IntPtr)WM_SYSKEYDOWN))
+        {
+            var info = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
+            var hotkey = new Hotkey(
+                (GetAsyncKeyState(0x5B) & 0x8000) != 0 || (GetAsyncKeyState(0x5C) & 0x8000) != 0,
+                (GetAsyncKeyState(0x11) & 0x8000) != 0,
+                (GetAsyncKeyState(0x10) & 0x8000) != 0,
+                (GetAsyncKeyState(0x12) & 0x8000) != 0,
+                (byte)info.vkCode);
+
+            if (!hotkey.Equals(default(Hotkey)) && _hotkeyMap.TryGetValue(hotkey, out string? actionId))
+            {
+                _processCommand?.Invoke(actionId);
+
+                INPUT[] input = new INPUT[1];
+                input[0].type = INPUT_KEYBOARD;
+                input[0].u.ki.wVk = 0xFF;
+                input[0].u.ki.dwFlags = KEYEVENTF_KEYUP;
+                SendInput(1, input, Marshal.SizeOf<INPUT>());
+                return (IntPtr)1;
+            }
+        }
+
+        return CallNextHookEx(_hook, nCode, wParam, lParam);
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+
+    private class HotkeyComparer : IComparer<Hotkey>
+    {
+        public int Compare(Hotkey x, Hotkey y)
+        {
+            int result = x.Key.CompareTo(y.Key);
+            if (result != 0) return result;
+            result = BoolCompare(x.Win, y.Win);
+            if (result != 0) return result;
+            result = BoolCompare(x.Ctrl, y.Ctrl);
+            if (result != 0) return result;
+            result = BoolCompare(x.Shift, y.Shift);
+            if (result != 0) return result;
+            return BoolCompare(x.Alt, y.Alt);
+        }
+
+        private static int BoolCompare(bool a, bool b) => a == b ? 0 : a ? 1 : -1;
+    }
+}

--- a/src/services/llsvc.keyboardlistener/llsvc.keyboardlistener.csproj
+++ b/src/services/llsvc.keyboardlistener/llsvc.keyboardlistener.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- wire up `KeyboardListener` in the capture manager
- drop Windows Forms requirement
- document listener usage in the README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466324f678832e9d292381e14a3dd8